### PR TITLE
add method to get byte position of reader

### DIFF
--- a/src/untrusted.rs
+++ b/src/untrusted.rs
@@ -220,6 +220,10 @@ impl<'a> Reader<'a> {
         Reader { input: input.value, i: 0 }
     }
 
+    /// Returns the position in the input.
+    #[inline]
+    pub fn pos(&self) -> usize { self.i }
+
     /// Returns `true` if the reader is at the end of the input, and `false`
     /// otherwise.
     #[inline]


### PR DESCRIPTION
i want to calculate the length in bytes of a der encoded cert buried in a variable-length packet.
by exposing the reader's byte position i hope to make it possible to read out the number of bytes consumed by the der parser.

see https://github.com/briansmith/webpki/pull/40