### PR TITLE
Change "license-file = .." into "license = ISC"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Brian Smith <brian@briansmith.org>"]
 description = "Safe, fast, zero-panic, zero-crashing, zero-allocation parsing of untrusted inputs in Rust."
 documentation = "https://briansmith.org/rustdoc/untrusted/"
-license-file = "LICENSE.txt"
+license = "ISC"
 name = "untrusted"
 readme = "README.md"
 repository = "https://github.com/briansmith/untrusted"


### PR DESCRIPTION
The license file can stay in repository, but removing "license-file" avoids one Cargo warning:

```
warning: only one of `license` or `license-file` is necessary
```

Fixes #12 

I agree to license my contributions to each file under the terms given at the top of each file I changed.