### PR TITLE
Remove unnecessary compiler profiles from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,5 @@ version = "0.6.0"
 name = "untrusted"
 
 [profile.bench]
-opt-level = 3
-debug = true
-rpath = false
+opt-level = 2
 lto = true
-debug-assertions = false
-codegen-units = 1
-
-[profile.release]
-opt-level = 3
-debug = true
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1


### PR DESCRIPTION
According to http://doc.crates.io/manifest.html:

> Cargo supports custom configuration of how rustc is invoked through profiles at the top level. Any manifest may declare a profile, but only the top level project’s profiles are actually read. All dependencies’ profiles will be overridden. This is done so the top-level project has control over how its dependencies are compiled.

This means profile.release is unneccessary.

This change keeps part of profile.bench. Testing with benchmark suite from PR #14 this profile gives the fastest results (on my machine).