### PR TITLE
Remove fat_ptr_transmutes lint. It has been removed in Rust 1.23

### DIFF
--- a/src/untrusted.rs
+++ b/src/untrusted.rs
@@ -98,7 +98,6 @@
 #![forbid(
     anonymous_parameters,
     box_pointers,
-    fat_ptr_transmutes,
     legacy_directory_ownership,
     missing_docs,
     trivial_casts,


### PR DESCRIPTION
Rust commit removing this lint can be found from https://github.com/rust-lang/rust/commit/bf0cdb52f22df2eb6a510806fa32b05ab326a93e

The warning from Rust 1.25:

```
warning: lint fat_ptr_transmutes has been removed: was accidentally removed back in 2014
   --> src/untrusted.rs:101:5
    |
101 |     fat_ptr_transmutes,
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(renamed_and_removed_lints)] on by default
```