### PR TITLE
[WIP] Derive Clone and Copy for Mark

### DIFF
--- a/src/untrusted.rs
+++ b/src/untrusted.rs
@@ -245,6 +245,7 @@ pub struct Reader<'a> {
 }
 
 /// An index into the already-parsed input of a `Reader`.
+#[derive(Clone, Copy)]
 pub struct Mark {
     i: usize
 }


### PR DESCRIPTION
⚠️ Please, don't merge yet. I need to think this more. Ideas also welcome.

Derive both `Clone` and `Copy` for `Mark`. Since `Mark` internally contains `usize` which is already `Copy` anyway this shouldn't be too much overhead. This makes is possible for `Reader::get_input_between_marks()` to get multiple `Input`s from one `Mark`. Another alternative would be for `Reader::get_input_between_marks()` to take reference of `Mark`, but I consider this implementation cleaner.

Some background: As a hobby proof-of-concept, I implemented DNS Message parser using `untrusted` and `untrustended`  and having the possibility to Copy `Mark` makes it easy to have `Input` for content already parsed which made it quite nice to parse DNS's compressed labels.