### PR TITLE
Remove now-redundant `#forbid(legacy_directory_ownership,)]`.

### DIFF
--- a/src/untrusted.rs
+++ b/src/untrusted.rs
@@ -89,7 +89,6 @@
 #![forbid(
     anonymous_parameters,
     box_pointers,
-    legacy_directory_ownership,
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,


### PR DESCRIPTION
The compiler was complaining about this, so remove it.