### PR TITLE
Reimplement fmt::Debug for Input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -13,11 +13,12 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 use crate::{no_panic, Reader};
+use core::fmt;
 
 /// A wrapper around `&'a [u8]` that helps in writing panic-free code.
 ///
 /// No methods of `Input` will ever panic.
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Eq)]
 pub struct Input<'a> {
     value: no_panic::Slice<'a>,
 }
@@ -110,5 +111,11 @@ impl PartialEq<Input<'_>> for [u8] {
     #[inline]
     fn eq(&self, other: &Input) -> bool {
         other.as_slice_less_safe() == self
+    }
+}
+
+impl fmt::Debug for Input<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.value, f)
     }
 }

--- a/src/no_panic.rs
+++ b/src/no_panic.rs
@@ -1,5 +1,7 @@
+use core::fmt;
+
 /// A wrapper around a slice that exposes no functions that can panic.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Slice<'a> {
     bytes: &'a [u8],
 }
@@ -33,5 +35,38 @@ impl<'a> Slice<'a> {
     #[inline]
     pub fn as_slice_less_safe(&self) -> &'a [u8] {
         self.bytes
+    }
+}
+
+/// Alternative implementation of `std::fmt::Debug` for byte slice.
+///
+/// Standard `Debug` implementation for `[u8]` is comma separated
+/// list of numbers. Since large amount of byte strings are in fact
+/// ASCII strings or contain a lot of ASCII strings (e. g. HTTP),
+/// it is convenient to print strings as ASCII when possible.
+impl fmt::Debug for Slice<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "b\"")?;
+        for &b in self.bytes {
+            // https://doc.rust-lang.org/reference/tokens.html#byte-escapes
+            if b == b'\n' {
+                write!(f, "\\n")?;
+            } else if b == b'\r' {
+                write!(f, "\\r")?;
+            } else if b == b'\t' {
+                write!(f, "\\t")?;
+            } else if b == b'\\' || b == b'"' {
+                write!(f, "\\{}", b as char)?;
+            } else if b == b'\0' {
+                write!(f, "\\0")?;
+                // ASCII printable
+            } else if (0x20..0x7f).contains(&b) {
+                write!(f, "{}", b as char)?;
+            } else {
+                write!(f, "\\x{:02x}", b)?;
+            }
+        }
+        write!(f, "\"")?;
+        Ok(())
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,6 +12,8 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use untrusted::Input;
+
 #[test]
 fn test_input_from() {
     let _ = untrusted::Input::from(b"foo");
@@ -100,4 +102,36 @@ fn test_vec_into() {
 fn test_from_slice() {
     let slice: &[u8] = &[0u8];
     let _x: untrusted::Input = slice.into();
+}
+
+#[test]
+fn test_debug() {
+    let vec: Vec<_> = (0..0x100).map(|b| b as u8).collect();
+
+    let expected = "b\"\
+        \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\
+        \\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\
+        \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\
+        \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f\
+        \x20!\\\"#$%&'()*+,-./0123456789:;<=>?\
+        @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_\
+        `abcdefghijklmnopqrstuvwxyz{|}~\\x7f\
+        \\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\
+        \\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\
+        \\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\
+        \\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\
+        \\xa0\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\
+        \\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\
+        \\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\
+        \\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\
+        \\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\
+        \\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\
+        \\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\
+        \\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xdf\
+        \\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\
+        \\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\
+        \\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\
+        \\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff\"";
+
+    assert_eq!(expected, format!("{:?}", Input::from(&vec)));
 }


### PR DESCRIPTION
For `Input::from(b"ab\n")` output `b"ab\n"`.

When working with webpki crate, some data is stored as `Input`,
while it in fact contains half-text data. Outputting ASCII as is
will help debugging the issues.

The implementation is copied from the `bytes` crate, where I submitted
it [long time ago](https://git.io/Jt1pD).

I agree to license my contributions to each file under the terms given at the top of each file I changed.