### PR TITLE
CI/CD: Remove optimization for owner's PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   push:
 jobs:
   rustfmt:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ubuntu-18.04
 
     steps:
@@ -23,9 +20,6 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ubuntu-18.04
 
     steps:
@@ -42,9 +36,6 @@ jobs:
       - run: cargo clippy --all-features ---all-targets -- --deny warnings
 
   audit:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ubuntu-18.04
 
     steps:
@@ -72,9 +63,6 @@ jobs:
       - run: cargo audit --deny warnings
 
   deny:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ubuntu-18.04
 
     steps:
@@ -101,9 +89,6 @@ jobs:
 
   # Verify that documentation builds.
   rustdoc:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ubuntu-18.04
 
     strategy:
@@ -131,9 +116,6 @@ jobs:
           cargo doc --all-features
 
   test:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ${{ matrix.host_os }}
 
     strategy:
@@ -177,9 +159,6 @@ jobs:
           cargo test -vv --target=${{ matrix.target }} ${{ matrix.cargo_options }} ${{ matrix.features }} ${{ matrix.mode }}
 
   coverage:
-    # Don't run duplicate `push` jobs for the repo owner's PRs.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     runs-on: ${{ matrix.host_os }}
 
     strategy:


### PR DESCRIPTION
The optimization where mostly-redundant CI jobs are skipped for the owner's
PRs is not too useful for this repository. And, those checks weren't
completely redundant anyway. So, remove this optimization. (It came from
*ring*, where such optimizations matter more, but even there I'm hoping to
remove them.)