### PR TITLE
Bump version number in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "ISC"
 name = "untrusted"
 readme = "README.md"
 repository = "https://github.com/briansmith/untrusted"
-version = "0.8.0"
+version = "0.9.0-not-released-yet"
 
 [lib]
 name = "untrusted"


### PR DESCRIPTION
Since 0.8.0 was yanked we can't use the 0.8.0 version number. Also since
we're planning to make breaking changes, we should increase the version
number anyway.