### PR TITLE
Avoid leaking potentially-secret information in `Debug` implementations.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -20,9 +20,17 @@ use crate::{no_panic, Reader};
 ///
 /// Intentionally avoids implementing `PartialEq` and `Eq` to avoid implicit
 /// non-constant-time comparisons.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Input<'a> {
     value: no_panic::Slice<'a>,
+}
+
+/// The value is intentionally omitted from the output to avoid leaking
+/// secrets.
+impl core::fmt::Debug for Input<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Input").finish()
+    }
 }
 
 impl<'a> Input<'a> {

--- a/src/no_panic.rs
+++ b/src/no_panic.rs
@@ -1,8 +1,8 @@
 /// A wrapper around a slice that exposes no functions that can panic.
 ///
-/// Intentionally avoids implementing `PartialEq` and `Eq` to avoid implicit
-/// non-constant-time comparisons.
-#[derive(Clone, Copy, Debug)]
+/// Intentionally avoids implementing `Debug`, `Eq`, and `PartialEq` to avoid
+/// creating a side channel that would leak information about the value.
+#[derive(Clone, Copy)]
 pub struct Slice<'a> {
     bytes: &'a [u8],
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -24,10 +24,17 @@ use crate::{no_panic, Input};
 ///
 /// Intentionally avoids implementing `PartialEq` and `Eq` to avoid implicit
 /// non-constant-time comparisons.
-#[derive(Debug)]
 pub struct Reader<'a> {
     input: no_panic::Slice<'a>,
     i: usize,
+}
+
+/// Avoids writing the value or position to avoid creating a side channel,
+/// though `Reader` can't avoid leaking the position via timing.
+impl core::fmt::Debug for Reader<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Reader").finish()
+    }
 }
 
 impl<'a> Reader<'a> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,23 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #[test]
+fn test_debug() {
+    const INPUTS: &[&[u8]] = &[b"", b"foo"];
+    for input in INPUTS {
+        let input = untrusted::Input::from(input);
+        assert_eq!(format!("{:?}", &input), "Input");
+        input
+            .read_all(untrusted::EndOfInput, |r| {
+                assert_eq!(format!("{:?}", r), "Reader");
+                r.skip_to_end();
+                assert_eq!(format!("{:?}", r), "Reader");
+                Ok(())
+            })
+            .unwrap();
+    }
+}
+
+#[test]
 fn test_input_clone_and_copy() {
     const INPUTS: &[&[u8]] = &[b"", b"a", b"foo"];
     for input in INPUTS {


### PR DESCRIPTION
`untrusted` made no promises as to what the `Debug` implementations
would do, and many users probably do want them to do what they were
doing, but in general the pain of accidentally leaking a secret value is
higher than the pain of the inconvenience of useless `Debug`
implementatoins, so make the `Debug` implementations useless.